### PR TITLE
remove font-size tool

### DIFF
--- a/example.main.scss
+++ b/example.main.scss
@@ -4,7 +4,6 @@
 
 // Tools
 @import 'tools/button-variant';
-@import 'tools/font-size';
 @import 'tools/fontello';
 
 // Generic

--- a/settings/_typography.scss
+++ b/settings/_typography.scss
@@ -1,4 +1,4 @@
-$base-font-size:                    1rem !default; // uses browser default as base, can be changed by setting a pixel value on html tag
+$base-font-size:                    1rem !default; // uses browser default as base, can be changed by setting a percentage / pixel value on html tag
 $base-line-height:                  1.5 !default;
 $base-font-family:                  -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif !default; /* stylelint-disable-line */
 

--- a/tools/_font-size.scss
+++ b/tools/_font-size.scss
@@ -1,9 +1,0 @@
-@function calculate-rem($size) {
-    $remSize: $size / $base-font-size;
-
-    @return $remSize * 1rem;
-}
-
-@mixin font-size($size) {
-    font-size: calculate-rem($size);
-}


### PR DESCRIPTION
as maat.css doesn't have a base-font-size in pixels anymore and we want to promote the usage of relative units for font sizing.